### PR TITLE
Add additional UI themes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -95,6 +95,50 @@
 }
 
 @layer base {
+    .theme-win95 {
+        --background: 0 0% 90%;
+        --foreground: 0 0% 0%;
+        --card: 0 0% 98%;
+        --card-foreground: 0 0% 0%;
+        --primary: 180 20% 30%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 0 0% 80%;
+        --secondary-foreground: 0 0% 0%;
+        --accent: 0 0% 60%;
+        --accent-foreground: 0 0% 0%;
+        --border: 0 0% 50%;
+        --input: 0 0% 95%;
+        --sidebar-background: 0 0% 85%;
+        --sidebar-foreground: 0 0% 0%;
+        --sidebar-primary: 180 20% 30%;
+        --sidebar-primary-foreground: 0 0% 100%;
+        --sidebar-accent: 0 0% 70%;
+        --sidebar-accent-foreground: 0 0% 0%;
+    }
+
+    .theme-futuristic {
+        --background: 240 5% 8%;
+        --foreground: 240 15% 85%;
+        --card: 240 5% 12%;
+        --card-foreground: 240 15% 90%;
+        --primary: 260 90% 60%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 220 5% 25%;
+        --secondary-foreground: 240 15% 90%;
+        --accent: 280 80% 70%;
+        --accent-foreground: 240 15% 10%;
+        --border: 240 5% 20%;
+        --input: 240 6% 25%;
+        --sidebar-background: 240 5% 10%;
+        --sidebar-foreground: 240 15% 85%;
+        --sidebar-primary: 260 90% 60%;
+        --sidebar-primary-foreground: 0 0% 100%;
+        --sidebar-accent: 280 80% 70%;
+        --sidebar-accent-foreground: 240 15% 10%;
+    }
+}
+
+@layer base {
     * {
         @apply border-border;
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,8 +28,6 @@ const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
 });
 
-const LIGHT_THEME_COLOR = 'hsl(0 0% 100%)';
-const DARK_THEME_COLOR = 'hsl(240deg 10% 3.92%)';
 const THEME_COLOR_SCRIPT = `\
 (function() {
   var html = document.documentElement;
@@ -40,8 +38,9 @@ const THEME_COLOR_SCRIPT = `\
     document.head.appendChild(meta);
   }
   function updateThemeColor() {
-    var isDark = html.classList.contains('dark');
-    meta.setAttribute('content', isDark ? '${DARK_THEME_COLOR}' : '${LIGHT_THEME_COLOR}');
+    var style = getComputedStyle(html);
+    var bg = style.getPropertyValue('--background').trim();
+    meta.setAttribute('content', 'hsl(' + bg + ')');
   }
   var observer = new MutationObserver(updateThemeColor);
   observer.observe(html, { attributes: true, attributeFilter: ['class'] });

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronUp } from 'lucide-react';
+import { ChevronUp, Palette } from 'lucide-react';
 import Image from 'next/image';
 import type { User } from 'next-auth';
 import { signOut, useSession } from 'next-auth/react';
@@ -10,6 +10,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
@@ -26,7 +32,7 @@ import { guestRegex } from '@/lib/constants';
 export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
   const { data, status } = useSession();
-  const { setTheme, resolvedTheme } = useTheme();
+  const { setTheme, theme } = useTheme();
 
   const isGuest = guestRegex.test(data?.user?.email ?? '');
 
@@ -71,13 +77,30 @@ export function SidebarUserNav({ user }: { user: User }) {
             side="top"
             className="w-[--radix-popper-anchor-width]"
           >
-            <DropdownMenuItem
-              data-testid="user-nav-item-theme"
-              className="cursor-pointer"
-              onSelect={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-            >
-              {`Toggle ${resolvedTheme === 'light' ? 'dark' : 'light'} mode`}
-            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="cursor-pointer">
+                <Palette />
+                <span>Theme</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent>
+                  <DropdownMenuRadioGroup
+                    value={theme}
+                    onValueChange={setTheme}
+                  >
+                    <DropdownMenuRadioItem value="system">
+                      Default
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="win95">
+                      Windows 95
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="futuristic">
+                      Futuristic
+                    </DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">
               <button

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -4,5 +4,12 @@ import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import type { ThemeProviderProps } from 'next-themes/dist/types';
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <NextThemesProvider
+      themes={['light', 'dark', 'win95', 'futuristic']}
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- add new Windows 95 and Futuristic theme variables
- allow switching to the new themes from the sidebar
- configure theme provider with extra themes
- update theme-color script to use active background color

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Served HTML report)*

------
https://chatgpt.com/codex/tasks/task_e_687649661b108333848df921b7eb884d